### PR TITLE
Fix Vercel types

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,2 +1,14 @@
-import expressApp from '../server/index.js';
-export default expressApp; 
+import expressAppPromise from '../server/index';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+let resolvedApp: any = null;
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+) {
+  if (!resolvedApp) {
+    resolvedApp = await expressAppPromise;
+  }
+  return resolvedApp(req, res);
+}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,7 +1,11 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
+import {
+  createServer as createViteServer,
+  createLogger,
+  type ServerOptions,
+} from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -20,7 +24,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,


### PR DESCRIPTION
## Summary
- add typed Vercel API handler
- type server options for Vite

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved serverless compatibility by updating the API handler to support asynchronous initialization.
	- Enhanced type safety in server configuration for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->