### PR TITLE
Fix blog post update timestamp

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -285,7 +285,7 @@ export class DrizzleStorage implements IStorage {
   
   async updateBlogPost(id: number, blogPost: Partial<Omit<BlogPost, 'id'>>): Promise<BlogPost | undefined> {
     const result = await db.update(blogPosts)
-      .set({ ...blogPost, updatedAt: new Date() })
+      .set({ ...blogPost, lastFetched: new Date() })
       .where(eq(blogPosts.id, id))
       .returning();
     return result[0];


### PR DESCRIPTION
## Summary
- use `lastFetched` when updating blog posts to match schema

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of blog post update tracking by updating the correct timestamp field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->