### PR TITLE
Fix blog-debug delete id mapping

### DIFF
--- a/client/src/pages/blog-debug.tsx
+++ b/client/src/pages/blog-debug.tsx
@@ -168,7 +168,7 @@ function SyncBlogPosts() {
   const [syncResult, setSyncResult] = useState<{imported: number} | null>(null);
   const [syncLoading, setSyncLoading] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
-  const [summary, setSummary] = useState<{count: number; titles: string[]} | null>(null);
+  const [summary, setSummary] = useState<{count: number; titles: string[]; ids: number[]} | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(false);
   
   const handleSync = async () => {
@@ -282,10 +282,11 @@ function SyncBlogPosts() {
                     <span>{title}</span>
                     <button
                       onClick={() => {
-                        // Get the actual post ID from the fetch posts response
-                        const postId = index + 1; // Placeholder - this should come from API
-                        handleDelete(postId);
-                      }} 
+                        const postId = summary.ids[index];
+                        if (postId !== undefined) {
+                          handleDelete(postId);
+                        }
+                      }}
                       className="text-red-600 hover:text-red-800 text-sm ml-4"
                     >
                       Delete


### PR DESCRIPTION
## Summary
- properly store post ids from blog summary
- use those ids when deleting posts in blog-debug

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of blog post deletion by ensuring the correct post is removed based on its unique ID.
  - Enhanced reliability when deleting blog posts, preventing accidental deletion of unintended posts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->