### PR TITLE
Fix build by removing edge runtime from blog posts API

### DIFF
--- a/app/api/blog/posts/route.ts
+++ b/app/api/blog/posts/route.ts
@@ -5,8 +5,6 @@ import DOMPurify from 'isomorphic-dompurify';
 // Define the RSS feed URL environment variable
 const RSS_FEED_URL = process.env.RSS_FEED_URL;
 
-// Set edge runtime (as per the skeleton comments)
-export const runtime = 'edge';
 
 // Set revalidation period
 export const revalidate = 3600; // 1 hour


### PR DESCRIPTION
## Summary
- remove `runtime = 'edge'` from `/api/blog/posts` so rss-parser can use Node APIs

## Testing
- `npm run build` *(fails: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled)*

------
https://chatgpt.com/codex/tasks/task_e_684cd906da88832487002be403587891