### PR TITLE
Fix server import path

### DIFF
--- a/api/handler.ts
+++ b/api/handler.ts
@@ -1,3 +1,5 @@
 // Vercel serverless handler – wraps Express app
-import app from '../server/index.ts';  // Vercel will transpile TS automatically
+// Import the Express app without a file extension so TypeScript
+// does not require `allowImportingTsExtensions` in the config.
+import app from '../server';
 export default app; 


### PR DESCRIPTION
## Summary
- remove `.ts` extension from `api/handler` import

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: missing module 'wouter')*

------
https://chatgpt.com/codex/tasks/task_e_684ce61c83a0832490e33e0628db8e02