### PR TITLE
Fix missing wouter dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gsap": "^3.13.0",
     "isomorphic-dompurify": "^1.9.0",
     "locomotive-scroll": "^4.1.4",
+    "wouter": "^3.7.1",
     "next": "14.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary
- add `wouter` library to project dependencies so that Next.js build can find the module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cfb2edfec8324a10ad7e5b3597da9